### PR TITLE
Update Hash Reader to use helper functions IsScalar() and IsContainer()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go v0.0.0-20200520044940-e32dee6c36bc
+	github.com/amzn/ion-go@master
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go@master
+	github.com/amzn/ion-go
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go v0.0.0-20200527142156-30f3e38dc649
+	github.com/amzn/ion-go v0.0.0-20200527212156-30f3e38dc649
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go
+	github.com/amzn/ion-go v0.0.0-20200527142156-30f3e38dc649
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 )

--- a/hash_reader.go
+++ b/hash_reader.go
@@ -51,12 +51,7 @@ func (hashReader *hashReader) SymbolTable() ion.SymbolTable {
 func (hashReader *hashReader) Next() bool {
 	if hashReader.currentType != ion.NoType {
 		if ion.IsScalar(hashReader.currentType) || hashReader.IsNull() {
-			panic("Not Implemented Yet")
-			// FIXME: hashReader.hasher.scalar() does not return anything
-			//err := hashReader.hasher.scalar(hashReader)
-			//if err != nil {
-			//	return false
-			//}
+			hashReader.hasher.scalar(hashReader)
 		} else {
 			err := hashReader.StepIn()
 			if err != nil {
@@ -102,25 +97,16 @@ func (hashReader *hashReader) Annotations() []string {
 }
 
 func (hashReader *hashReader) StepIn() error {
-	panic("Not Implemented Yet")
-	// FIXME: hashReader.hasher.stepIn() does not return a value
-	/*
-		err := hashReader.hasher.stepIn(hashReader)
+	hashReader.hasher.stepIn(hashReader)
 
-		if err != nil {
-			return err
-		}
+	err := hashReader.ionReader.StepIn()
+	if err != nil {
+		return err
+	}
 
-		err = hashReader.ionReader.StepIn()
-		if err != nil {
-			return err
-		}
+	hashReader.currentType = ion.NoType
 
-		hashReader.currentType = ion.NoType
-
-		return nil
-
-	*/
+	return nil
 }
 
 func (hashReader *hashReader) StepOut() error {

--- a/hash_reader.go
+++ b/hash_reader.go
@@ -174,7 +174,7 @@ func (hashReader *hashReader) Sum(b []byte) []byte {
 
 func (hashReader *hashReader) traverse() error {
 	for hashReader.Next() {
-		if ion.IsContainer(hashReader.currentType) && !hashReader.IsNull(){
+		if ion.IsContainer(hashReader.currentType) && !hashReader.IsNull() {
 			err := hashReader.StepIn()
 			if err != nil {
 				return err

--- a/hash_reader.go
+++ b/hash_reader.go
@@ -50,30 +50,23 @@ func (hashReader *hashReader) SymbolTable() ion.SymbolTable {
 
 func (hashReader *hashReader) Next() bool {
 	if hashReader.currentType != ion.NoType {
-		if ion.IsContainer(hashReader.currentType) {
-			if hashReader.IsNull() {
-				err := hashReader.hasher.scalar(hashReader)
-				if err != nil {
-					return false
-				}
-			} else {
-				err := hashReader.StepIn()
-				if err != nil {
-					return false
-				}
-
-				err = hashReader.traverse()
-				if err != nil {
-					return false
-				}
-
-				err = hashReader.StepOut()
-				if err != nil {
-					return false
-				}
-			}
-		} else if ion.IsScalar(hashReader.currentType) {
+		if ion.IsScalar(hashReader.currentType) || hashReader.IsNull() {
 			err := hashReader.hasher.scalar(hashReader)
+			if err != nil {
+				return false
+			}
+		} else {
+			err := hashReader.StepIn()
+			if err != nil {
+				return false
+			}
+
+			err = hashReader.traverse()
+			if err != nil {
+				return false
+			}
+
+			err = hashReader.StepOut()
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
Now that https://github.com/amzn/ion-go/issues/34 is resolved, we can update the hash reader code to use the helper functions IsScalar() and IsContainer().