### PR TITLE
Update crypto hasher provider functions to be exportable

### DIFF
--- a/crypto_hasher_provider.go
+++ b/crypto_hasher_provider.go
@@ -21,10 +21,10 @@ type cryptoHasherProvider struct {
 	algorithm algorithm
 }
 
-func newCryptoHasherProvider(algorithm algorithm) *cryptoHasherProvider {
+func NewCryptoHasherProvider(algorithm algorithm) *cryptoHasherProvider {
 	return &cryptoHasherProvider{algorithm: algorithm}
 }
 
-func (chp *cryptoHasherProvider) newHasher() (IonHasher, error) {
+func (chp *cryptoHasherProvider) NewHasher() (IonHasher, error) {
 	return newCryptoHasher(chp.algorithm)
 }

--- a/crypto_hasher_provider.go
+++ b/crypto_hasher_provider.go
@@ -21,10 +21,12 @@ type cryptoHasherProvider struct {
 	algorithm algorithm
 }
 
+// NewCryptoHasherProvider returns a new cryptoHasherProvider.
 func NewCryptoHasherProvider(algorithm algorithm) *cryptoHasherProvider {
 	return &cryptoHasherProvider{algorithm: algorithm}
 }
 
+// NewHasher returns a new cryptoHasher.
 func (chp *cryptoHasherProvider) NewHasher() (IonHasher, error) {
 	return newCryptoHasher(chp.algorithm)
 }

--- a/hasher.go
+++ b/hasher.go
@@ -24,7 +24,7 @@ type hasher struct {
 }
 
 func newHasher(hasherProvider IonHasherProvider) (*hasher, error) {
-	newHasher, err := hasherProvider.newHasher()
+	newHasher, err := hasherProvider.NewHasher()
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (h *hasher) stepIn(ionValue hashValue) error {
 
 	_, ok := h.currentHasher.(*structSerializer)
 	if ok {
-		newHasher, err := h.hasherProvider.newHasher()
+		newHasher, err := h.hasherProvider.NewHasher()
 		if err != nil {
 			return err
 		}

--- a/identity_hasher_provider.go
+++ b/identity_hasher_provider.go
@@ -23,6 +23,6 @@ func newIdentityHasherProvider() *identityHasherProvider {
 	return &identityHasherProvider{}
 }
 
-func (ihp *identityHasherProvider) newHasher() (IonHasher, error) {
+func (ihp *identityHasherProvider) NewHasher() (IonHasher, error) {
 	return newIdentityIonHasher(), nil
 }

--- a/ion_hasher_provider.go
+++ b/ion_hasher_provider.go
@@ -18,5 +18,5 @@ package ionhash
 // IonHasherProvider used for creating new instances of IonHasher.
 type IonHasherProvider interface {
 	// Return a new IonHasher object.
-	newHasher() (IonHasher, error)
+	NewHasher() (IonHasher, error)
 }

--- a/struct_serializer.go
+++ b/struct_serializer.go
@@ -29,7 +29,7 @@ type structSerializer struct {
 }
 
 func newStructSerializer(hashFunction IonHasher, depth int, hashFunctionProvider IonHasherProvider) (serializer, error) {
-	newHasher, err := hashFunctionProvider.newHasher()
+	newHasher, err := hashFunctionProvider.NewHasher()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Update crypto_hasher_provider.go functions to be exportable so packages can use it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
