### PR TITLE
Reduce failures for TestIonReaderContract()

### DIFF
--- a/base_serializer.go
+++ b/base_serializer.go
@@ -348,6 +348,11 @@ func serializers(ionType ion.Type, ionValue interface{}, writer ion.Writer) erro
 			return writer.WriteUint(uint64(ionValUint32))
 		}
 
+		ionValInt, ok := ionValue.(int)
+		if ok {
+			return writer.WriteInt(int64(ionValInt))
+		}
+
 		ionValBigInt, ok := ionValue.(*big.Int)
 		if ok {
 			return writer.WriteBigInt(ionValBigInt)

--- a/hash_reader.go
+++ b/hash_reader.go
@@ -250,7 +250,24 @@ func (hashReader *hashReader) value() (interface{}, error) {
 	case ion.FloatType:
 		return hashReader.FloatValue()
 	case ion.IntType:
-		return hashReader.Int64Value()
+		intSize, err := hashReader.IntSize()
+		if err != nil {
+			return nil, err
+		}
+
+		switch intSize {
+		case ion.Int32:
+			return hashReader.IntValue()
+		case ion.Int64:
+			return hashReader.Int64Value()
+		case ion.Uint64:
+			return hashReader.Uint64Value()
+		case ion.BigInt:
+			return hashReader.BigIntValue()
+		default:
+			return nil, &InvalidOperationError{
+				"hashReader", "value", "Expected intSize to be one of Int32, Int64, Uint64, or BigInt"}
+		}
 	case ion.StringType:
 		return hashReader.StringValue()
 	case ion.SymbolType:

--- a/hash_reader_test.go
+++ b/hash_reader_test.go
@@ -102,14 +102,14 @@ func TestReaderUnresolvedSid(t *testing.T) {
 }
 
 func TestIonReaderContract(t *testing.T) {
-	t.Skip()
+	t.Skip() // Skipping test until SymbolToken is implemented
 
 	file, err := ioutil.ReadFile("ion-hash-test/ion_hash_tests.ion")
 	require.NoError(t, err, "Something went wrong loading ion_hash_tests.ion")
 
 	reader := ion.NewReaderBytes(file)
 
-	ionHashReader, err := NewHashReader(reader, newIdentityHasherProvider())
+	ionHashReader, err := NewHashReader(ion.NewReaderBytes(file), newIdentityHasherProvider())
 	require.NoError(t, err, "Expected NewHashReader() to successfully create a HashReader")
 
 	compareReaders(t, reader, ionHashReader)

--- a/testing_utilities.go
+++ b/testing_utilities.go
@@ -136,7 +136,15 @@ func compareScalars(t *testing.T, ionType ion.Type, reader1 ion.Reader, reader2 
 		assert.NoError(t, err, "Something went wrong executing reader1.IntSize()")
 
 		switch intSize {
-		case ion.Int32, ion.Int64:
+		case ion.Int32:
+			int1, err := reader1.IntValue()
+			assert.NoError(t, err, "Something went wrong executing reader1.IntValue()")
+
+			int2, err := reader2.IntValue()
+			assert.NoError(t, err, "Something went wrong executing reader2.IntValue()")
+
+			assert.Equal(t, int1, int2, "Expected int values to match")
+		case ion.Int64:
 			int1, err := reader1.Int64Value()
 			assert.NoError(t, err, "Something went wrong executing reader1.Int64Value()")
 

--- a/testing_utilities.go
+++ b/testing_utilities.go
@@ -56,16 +56,20 @@ func compareReaders(t *testing.T, reader1 ion.Reader, reader2 ion.Reader) {
 			assert.True(t, isNull2, "Expected reader2.IsNull() to return true")
 		} else if ion.IsScalar(type1) {
 			compareScalars(t, type1, reader1, reader2)
-		} else if ion.IsContainer(type1) && !isNull1 {
-			assert.NoError(t, reader1.StepIn(), "Something went wrong executing reader1.StepIn()")
+		} else if ion.IsContainer(type1) {
+			if !isNull1 {
+				assert.NoError(t, reader1.StepIn(), "Something went wrong executing reader1.StepIn()")
 
-			assert.NoError(t, reader2.StepIn(), "Something went wrong executing reader2.StepIn()")
+				assert.NoError(t, reader2.StepIn(), "Something went wrong executing reader2.StepIn()")
 
-			compareReaders(t, reader1, reader2)
+				compareReaders(t, reader1, reader2)
 
-			assert.NoError(t, reader1.StepOut(), "Something went wrong executing reader1.StepOut()")
+				assert.NoError(t, reader1.StepOut(), "Something went wrong executing reader1.StepOut()")
 
-			assert.NoError(t, reader2.StepOut(), "Something went wrong executing reader2.StepOut()")
+				assert.NoError(t, reader2.StepOut(), "Something went wrong executing reader2.StepOut()")
+			}
+		} else {
+			t.Error(&InvalidIonTypeError{type1})
 		}
 	}
 


### PR DESCRIPTION
There are many test cases in "ion_hash_tests.ion" and several of them were failing in TestIonReaderContract(). This PR fixes some of the failures but not all failures as we are waiting for SymbolToken to be implemented in ion-go.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
