### PR TITLE
refactor: move stack implementation to internal folder

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/amzn/ion-go v0.0.0-20200520044940-e32dee6c36bc/go.mod h1:EZ4HohQB+x+U
 github.com/amzn/ion-go v0.0.0-20200527212156-30f3e38dc649 h1:MeTMbaAJBgzWe52goAkhDHDo1ZAOyfV6wUo8XViacnM=
 github.com/amzn/ion-go v0.0.0-20200527212156-30f3e38dc649/go.mod h1:EZ4HohQB+x+U+xenCu/pm4jAwlBtHhQ02V2asw8LCfo=
 github.com/amzn/ion-go v0.0.0-20200623134041-78eeb7783dea h1:0/JQXUrrBeKpfv3eLv2Huwz3tYQaUaPUtqzMcLrAl/k=
+github.com/amzn/ion-go v0.0.0-20200702220820-7d3cd45adbee h1:a8iWR7kl0+Lje+Pt9DFYn0/5YpHxQF5/hYJ3v4hylqg=
+github.com/amzn/ion-go v0.0.0-20200702220820-7d3cd45adbee/go.mod h1:EZ4HohQB+x+U+xenCu/pm4jAwlBtHhQ02V2asw8LCfo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/stack.go
+++ b/internal/stack.go
@@ -17,19 +17,20 @@ package internal
 
 import "errors"
 
+// Stack implementation used internally.
 type Stack []interface{}
 
-// Check if Stack is empty
+// IsEmpty returns `true` if stack is empty, false otherwise.
 func (s *Stack) IsEmpty() bool {
 	return len(*s) == 0
 }
 
-// Push element into Stack
+// Push element into Stack.
 func (s *Stack) Push(element interface{}) {
 	*s = append(*s, element)
 }
 
-// Remove and return top element of Stack. Return error if Stack is empty.
+// Pop removes and return top element of Stack. Return error if Stack is empty.
 func (s *Stack) Pop() (interface{}, error) {
 	if s.IsEmpty() {
 		return nil, errors.New("Pop() called on an empty Stack")
@@ -42,7 +43,7 @@ func (s *Stack) Pop() (interface{}, error) {
 	return element, nil
 }
 
-// Return top element of Stack. Return error if Stack is empty.
+// Peek returns the top element of the Stack. Return error if Stack is empty.
 func (s *Stack) Peek() (interface{}, error) {
 	if s.IsEmpty() {
 		return nil, errors.New("Peek() called on an empty Stack")
@@ -54,7 +55,7 @@ func (s *Stack) Peek() (interface{}, error) {
 	return element, nil
 }
 
-// Return number of elements in Stack
+// Size returns the number of elements in the Stack
 func (s *Stack) Size() int {
 	return len(*s)
 }

--- a/internal/stack.go
+++ b/internal/stack.go
@@ -13,37 +13,39 @@
  * permissions and limitations under the License.
  */
 
-package ionhash
+package internal
 
-type stack []interface{}
+import "errors"
 
-// Check if stack is empty
-func (s *stack) isEmpty() bool {
+type Stack []interface{}
+
+// Check if Stack is empty
+func (s *Stack) IsEmpty() bool {
 	return len(*s) == 0
 }
 
-// Push element into stack
-func (s *stack) push(element interface{}) {
+// Push element into Stack
+func (s *Stack) Push(element interface{}) {
 	*s = append(*s, element)
 }
 
-// Remove and return top element of stack. Return error if stack is empty.
-func (s *stack) pop() (interface{}, error) {
-	if s.isEmpty() {
-		return nil, &InvalidOperationError{"stack", "pop", "stack is empty"}
+// Remove and return top element of Stack. Return error if Stack is empty.
+func (s *Stack) Pop() (interface{}, error) {
+	if s.IsEmpty() {
+		return nil, errors.New("Pop() called on an empty Stack")
 	}
 
 	index := len(*s) - 1   // Get the index of the top most element.
 	element := (*s)[index] // Index into the slice and obtain the element.
-	*s = (*s)[:index]      // Remove it from the stack by slicing it off.
+	*s = (*s)[:index]      // Remove it from the Stack by slicing it off.
 
 	return element, nil
 }
 
-// Return top element of stack. Return error if stack is empty.
-func (s *stack) peek() (interface{}, error) {
-	if s.isEmpty() {
-		return nil, &InvalidOperationError{"stack", "pop", "stack is empty"}
+// Return top element of Stack. Return error if Stack is empty.
+func (s *Stack) Peek() (interface{}, error) {
+	if s.IsEmpty() {
+		return nil, errors.New("Peek() called on an empty Stack")
 	}
 
 	index := len(*s) - 1   // Get the index of the top most element.
@@ -52,7 +54,7 @@ func (s *stack) peek() (interface{}, error) {
 	return element, nil
 }
 
-// Return number of elements in stack
-func (s *stack) size() int {
+// Return number of elements in Stack
+func (s *Stack) Size() int {
 	return len(*s)
 }

--- a/internal/stack.go
+++ b/internal/stack.go
@@ -43,7 +43,7 @@ func (s *Stack) Pop() (interface{}, error) {
 	return element, nil
 }
 
-// Peek returns the top element of the Stack. Return error if Stack is empty.
+// Peek returns the top element of the Stack. Returns an error if the Stack is empty.
 func (s *Stack) Peek() (interface{}, error) {
 	if s.IsEmpty() {
 		return nil, errors.New("Peek() called on an empty Stack")

--- a/internal/stack.go
+++ b/internal/stack.go
@@ -30,7 +30,7 @@ func (s *Stack) Push(element interface{}) {
 	*s = append(*s, element)
 }
 
-// Pop removes and return top element of Stack. Return error if Stack is empty.
+// Pop removes and returns the top element of the Stack. Returns an error if the Stack is empty.
 func (s *Stack) Pop() (interface{}, error) {
 	if s.IsEmpty() {
 		return nil, errors.New("Pop() called on an empty Stack")


### PR DESCRIPTION
Issue #, if available: related to #31 

Description of changes:

* Moves `stack` implementation to internal folder 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
