### PR TITLE
prep v1.0.0-rc candidate

### DIFF
--- a/cmd/ion-hash
+++ b/cmd/ion-hash
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cd $(dirname "$0")
-go run ion-hash.go $@

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go v0.1.0-beta.0.20200916184209-44c01469395a
+	github.com/amzn/ion-go v1.0.0-rc
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/amzn/ion-go v0.1.0-beta h1:wt2TptG/JjH0aCjt4F2XZhJHolxsIHketWAiY/bbfco=
-github.com/amzn/ion-go v0.1.0-beta/go.mod h1:ZuzRHzi/dpnh5Y7jstvkKKXnA6D9vt+840eNrtoSvtw=
-github.com/amzn/ion-go v0.1.0-beta.0.20200916184209-44c01469395a h1:bJ5YPsz/yYcIEaQo4M9Am9GhjPjpZ1sg2AkCNlrEhGw=
-github.com/amzn/ion-go v0.1.0-beta.0.20200916184209-44c01469395a/go.mod h1:ZuzRHzi/dpnh5Y7jstvkKKXnA6D9vt+840eNrtoSvtw=
+github.com/amzn/ion-go v1.0.0-rc h1:8JKbZxNMgXCmLyLrXmbrVe5WmtBk4nQLXN41UxTJFVE=
+github.com/amzn/ion-go v1.0.0-rc/go.mod h1:ZuzRHzi/dpnh5Y7jstvkKKXnA6D9vt+840eNrtoSvtw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION

Description of changes:

* Move to ion-go v1.0.0-rc 
* go.sum cleanup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
