### PR TITLE
Move ion-go dependency to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go v1.0.0-rc
+	github.com/amzn/ion-go v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/amzn/ion-go v1.0.0-rc h1:8JKbZxNMgXCmLyLrXmbrVe5WmtBk4nQLXN41UxTJFVE=
-github.com/amzn/ion-go v1.0.0-rc/go.mod h1:ZuzRHzi/dpnh5Y7jstvkKKXnA6D9vt+840eNrtoSvtw=
+github.com/amzn/ion-go v1.0.0 h1:9mubV+ZapUEMN8JAtljmcpApDbtXN4Z2aREPBlz1A2o=
+github.com/amzn/ion-go v1.0.0/go.mod h1:6cXCj/jj1hops6F7AzLtW0VrB1eTCBWZ+e2iFiWwwgU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION


Description of changes:

Move ion-go to v1.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
