### PR TITLE
ion-go bump to v1.1.0, go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go v1.0.2-0.20201109205222-c1fd17e8273b
+	github.com/amzn/ion-go v1.1.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/amzn/ion-go v1.0.1 h1:yF77ma7UT8aNm2B85xJqb4XheC2HaI0b3s/+lZUxVk4=
-github.com/amzn/ion-go v1.0.1/go.mod h1:93Bu1K0O/CDosTCDzJ1cNY7XpdHGAGE2NepHcGsiV70=
-github.com/amzn/ion-go v1.0.2-0.20201109205222-c1fd17e8273b h1:gug9/TAAy0kH3cA5KeU9foPj4KpXm98hYCRqZ4oc92Y=
-github.com/amzn/ion-go v1.0.2-0.20201109205222-c1fd17e8273b/go.mod h1:93Bu1K0O/CDosTCDzJ1cNY7XpdHGAGE2NepHcGsiV70=
+github.com/amzn/ion-go v1.1.0 h1:699A2uZDtkPf5yTMcRkTMoCBYa0UELLgAt0k8Psw+RY=
+github.com/amzn/ion-go v1.1.0/go.mod h1:93Bu1K0O/CDosTCDzJ1cNY7XpdHGAGE2NepHcGsiV70=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Description of changes:
* Bumps the `ion-go` dependency version to `1.1.0`
* Runs `go mod tidy`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
