### PR TITLE
ion-go bump to v1.1.3 and go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/amzn/ion-hash-go
 go 1.13
 
 require (
-	github.com/amzn/ion-go v1.1.2
+	github.com/amzn/ion-go v1.1.3
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/amzn/ion-go v1.1.2 h1:4hizhL8PQ+XOmJIpycq23/YWoXhEztK0LHYMTZSxsu8=
-github.com/amzn/ion-go v1.1.2/go.mod h1:7wQBWQ7PhPpZCr9PL+mtuIyNmyLjuV8qt2mrfxmvkA8=
+github.com/amzn/ion-go v1.1.3 h1:gGhjtLY0GUNQXej5N2qHhoVWQBkgtoPDt1feYYFMfOc=
+github.com/amzn/ion-go v1.1.3/go.mod h1:7wQBWQ7PhPpZCr9PL+mtuIyNmyLjuV8qt2mrfxmvkA8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Description of changes:
This PR bumps ion-go to `v1.1.3` and adds go mod tidy changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
